### PR TITLE
Use full fingerprint of new key.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@ class spotify {
     location          => 'http://repository.spotify.com',
     release           => 'stable',
     repos             => 'non-free',
-    key               => '94558F59',
+    key               => 'BBEBDCB318AD50EC6865090613B00F1FD2C19886',
     include_src       => false,
   }
 


### PR DESCRIPTION
Running this on puppet 4.2.2 I got the following warning:

```
Warning: /Apt_key[Add key: 94558F59 from Apt::Source spotify]: The id should be a full fingerprint (40 characters), see README.
```

I updated the key to the full 40 char fingerprint of the (new) key. I tried running the tests in Ruby 1.9.3 and 2.2.2 but always got:

```
Puppet::Error:
       Syntax error at '{'; expected '}' at /garethr-spotify/spec/fixtures/modules/apt/manifests/init.pp:19 on node diffie.sk.lan
```

 Let me know your thoughts.
